### PR TITLE
Adding support for multiple nested expansions

### DIFF
--- a/expander/parse_qs.py
+++ b/expander/parse_qs.py
@@ -1,0 +1,40 @@
+
+from collections import defaultdict
+
+
+def dict_from_qs(qs):
+    ''' Slightly introverted parser for lists of dot-notation nested fields
+        i.e. "period.di,period.fhr" => {"period": {"di": {}, "fhr": {}}}
+    '''
+    entries = qs.split(',') if qs.strip() else []
+    entries = [entry.strip() for entry in entries]
+
+    def _dict_from_qs(line, d):
+        if '.' in line:
+            key, value = line.split('.', 1)
+            return _dict_from_qs(value, d[key])
+        else:
+            d[line] = {}
+
+    def _default():
+        return defaultdict(_default)
+
+    d = defaultdict(_default)
+    for line in entries:
+        _dict_from_qs(line, d)
+    return d
+
+
+def qs_from_dict(qsdict, prefix=""):
+    ''' Same as dict_from_qs, but in reverse
+        i.e. {"period": {"di": {}, "fhr": {}}} => "period.di,period.fhr"
+    '''
+    prefix = prefix + '.' if prefix else ""
+
+    def descend(qsd):
+        for key, val in sorted(qsd.items()):
+            if val:
+                yield qs_from_dict(val, prefix + key)
+            else:
+                yield prefix + key
+    return ",".join(descend(qsdict))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import factory
 
-from .project.models import Restaurant, Menu, PriceBracket, MenuItem, \
+from .project.models import Restaurant, Chef, Menu, PriceBracket, MenuItem, \
     MenuItemOption, MenuItemOptionChoice
 
 
@@ -13,8 +13,17 @@ class RestaurantFactory(factory.DjangoModelFactory):
         model = Restaurant
 
 
+class ChefFactory(factory.DjangoModelFactory):
+    name = "DeGarnier"
+    stars = 4
+
+    class Meta:
+        model = Chef
+
+
 class MenuFactory(factory.DjangoModelFactory):
     restaurant = factory.SubFactory(RestaurantFactory)
+    chef = factory.SubFactory(ChefFactory)
     title = 'Breakfast'
 
     class Meta:

--- a/tests/project/migrations/0001_initial.py
+++ b/tests/project/migrations/0001_initial.py
@@ -67,4 +67,17 @@ class Migration(migrations.Migration):
             name='restaurant',
             field=models.ForeignKey(related_name='menus', to='project.Restaurant'),
         ),
+        migrations.CreateModel(
+            name='Chef',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=128)),
+                ('stars', models.IntegerField()),
+            ],
+        ),
+        migrations.AddField(
+            model_name='menu',
+            name='chef',
+            field=models.ForeignKey(related_name='menus', to='project.Chef'),
+        ),
     ]

--- a/tests/project/models.py
+++ b/tests/project/models.py
@@ -5,8 +5,14 @@ class Restaurant(models.Model):
     title = models.CharField(max_length=128)
 
 
+class Chef(models.Model):
+    name = models.CharField(max_length=128)
+    stars = models.IntegerField()
+
+
 class Menu(models.Model):
     restaurant = models.ForeignKey('Restaurant', related_name='menus')
+    chef = models.ForeignKey('Chef', related_name='menus')
     title = models.CharField(max_length=128)
 
 

--- a/tests/project/views.py
+++ b/tests/project/views.py
@@ -3,7 +3,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from expander import ExpanderSerializerMixin
 
-from .models import Restaurant, Menu, PriceBracket, MenuItem, \
+from .models import Restaurant, Chef, Menu, PriceBracket, MenuItem, \
     MenuItemOption, MenuItemOptionChoice
 
 
@@ -13,12 +13,19 @@ class RestaurantSerializer(ExpanderSerializerMixin, serializers.ModelSerializer)
         fields = ('id', 'title')
 
 
+class ChefSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Chef
+        fields = ('id', 'name', 'stars')
+
+
 class MenuSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = Menu
         fields = ('id', 'restaurant', 'title')
         expandable_fields = {
             'restaurant': RestaurantSerializer,
+            'chef': ChefSerializer,
         }
 
 


### PR DESCRIPTION
Howdy. I was hoping to get your feedback on this. I was going to use your serializer in work, but needed the ability to expand multiple nested expansions.

This branch will expand the "expand" field as a dict and use that for its nested serializers. It appears to be working against my codebase, including list etc, quite well.

Hope this seems useful enough to you for inclusion in your project,

thanks,

Ray