### PR TITLE
Fixing bug where the expandable fields' state was being altered in be…

### DIFF
--- a/expander/serializers.py
+++ b/expander/serializers.py
@@ -43,6 +43,7 @@ class ExpanderSerializerMixin(object):
                     kwargs = {}
                     serializer_class = serializer_class_info
 
+                kwargs = kwargs.copy()
                 kwargs.setdefault('context', self.context)
 
                 # If the serializer class isn't an expander then it can't

--- a/tests/project/views.py
+++ b/tests/project/views.py
@@ -41,7 +41,7 @@ class MenuItemSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
         fields = ('id', 'menu', 'title', 'description', 'price')
         expandable_fields = {
             'menu': MenuSerializer,
-            'price_bracket': PriceBracketSerializer,
+            'price_bracket': (PriceBracketSerializer, (), {}),
         }
 
 

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -3,6 +3,7 @@ from rest_framework import status
 import pytest
 
 import tests.factories as f
+import tests.project.views as test_views
 from expander.parse_qs import qs_from_dict
 from expander.parse_qs import dict_from_qs
 
@@ -89,6 +90,20 @@ def test_it_should_be_able_to_expand_multiple_nested_fields(client):
         },
         'title': menu_item.menu.title
     }
+
+
+def test_kwargs_reused_across_requests(client):
+    meta = test_views.MenuItemSerializer.Meta
+    price_bracket_spec = meta.expandable_fields['price_bracket']
+
+    assert (test_views.PriceBracketSerializer, (), {}) == price_bracket_spec
+
+    menu_item = f.MenuItemFactory()
+    r = client.get('/menu-items/%s/?expand=menu.restaurant,menu.chef' % (
+        menu_item.pk,))
+
+    # Spec has not been altered
+    assert (test_views.PriceBracketSerializer, (), {}) == price_bracket_spec
 
 
 def test_can_parse_expand_querystring(client):


### PR DESCRIPTION
…tween requests. Hi silverlogic. I've found a subtle but fairly serious bug where query params were being propagated between requests. It occurs under the following conditions:

When an expandable field is specified using the tuple syntax instead of a class reference, the kwargs var was being altered with a previous requests' context. This seems to only kick in for nested expansions. 

Found this at our end because we're using another serializer to specify the fields. For nested resources, these fields were showing up in the next request, so:

When calling:

/resources/1?expand=sub.nested&fields=name,address

The json would come back correctly:

{'sub': {'nested': {'name': 'Bob', 'address': 'home'}}}

but on another call, with different (or no) fields specified, the original fields values "name,address" was being used:

/resources/1?expand=sub.nested

{'sub': {'nested': {'name': 'Bob', 'address': 'home'}}}

...still name/address only

this fix should address that. Hope it's helpful.