### PR TITLE
Prevent infinite recursion with circular expandable fields

### DIFF
--- a/expander/serializers.py
+++ b/expander/serializers.py
@@ -15,7 +15,7 @@ class ExpanderSerializerMixin(object):
         if not expandable_fields:
             return
 
-        if not expanded_fields:
+        if expanded_fields is None:
             context = self.context
             if not context:
                 return

--- a/tests/project/urls.py
+++ b/tests/project/urls.py
@@ -1,10 +1,11 @@
 from rest_framework import routers
 
-from .views import MenuItemViewSet, MenuItemOptionViewSet
+from .views import ChefViewSet, MenuItemViewSet, MenuItemOptionViewSet
 
 
 router = routers.SimpleRouter()
 
+router.register('chef', ChefViewSet)
 router.register('menu-items', MenuItemViewSet)
 router.register('menu-item-options', MenuItemOptionViewSet)
 

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -131,3 +131,18 @@ def test_can_reverse_parse_dict_to_querystring(client):
             qs_from_dict({"fhr": {"inner1": {
                          "inner2": {}, "inner3": {}}},
                          "di": {}}))
+
+
+def test_recursive_fields(client):
+    menu = f.MenuFactory()
+    chef = menu.chef
+    r = client.get('/chef/%s/?expand=menus.restaurant.menu' % (
+        chef.pk,))
+    assert r.data['menus'][0] == {
+        'id': chef.menus.first().id,
+        'restaurant': {
+            'id': chef.menus.first().restaurant.pk,
+            'title': chef.menus.first().restaurant.title,
+        },
+        'title': chef.menus.first().title
+    }


### PR DESCRIPTION
In certain circumstances, serializers with recursive `expandable_fields` (for example, serializer A has serializer B inits `expandable_fields`, serializer B has serializer C in its `expandable_fields`, and serialier C has serializer A in its `expandable_fields`) and a nested `expand` query parameter can cause infinite recursion when instantiating the `ExpanderSerializerMixin`.

In short, when what should be the end of recursively instantiating `ExpanderSerializerMixin`s, the `expanded_fields` variable is an empty string, so `expanded_fields` is recreated in whole from `request.query_params`. If `expandable_fields` is circular, the `if expanded_field in expandable_fields` can pass, starting infinite recursion.

The fix is to only create `expanded_fields` from `request.query_params` if it is None, which only occurs at the beginning of the chain of instantiation.