### PR TITLE
Use tox-travis to match python versions with envlist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,19 @@
 language: python
 
 python:
+  - '2.7'
+  - '3.2'
+  - '3.3'
+  - '3.4'
   - '3.5'
 
 sudo: false
 
-env:
-  - TOX_ENV=py27-django1.7-drf3.1
-  - TOX_ENV=py27-django1.7-drf3.2
-  - TOX_ENV=py27-django1.7-drf3.3
-  - TOX_ENV=py27-django1.8-drf3.1
-  - TOX_ENV=py27-django1.8-drf3.2
-  - TOX_ENV=py27-django1.8-drf3.3
-  - TOX_ENV=py27-django1.9-drf3.1
-  - TOX_ENV=py27-django1.9-drf3.2
-  - TOX_ENV=py27-django1.9-drf3.3
-
-  - TOX_ENV=py32-django1.7-drf3.1
-  - TOX_ENV=py32-django1.7-drf3.2
-  - TOX_ENV=py32-django1.7-drf3.3
-  - TOX_ENV=py32-django1.8-drf3.1
-  - TOX_ENV=py32-django1.8-drf3.2
-  - TOX_ENV=py32-django1.8-drf3.3
-
-  - TOX_ENV=py33-django1.7-drf3.1
-  - TOX_ENV=py33-django1.7-drf3.2
-  - TOX_ENV=py33-django1.7-drf3.3
-  - TOX_ENV=py33-django1.8-drf3.1
-  - TOX_ENV=py33-django1.8-drf3.2
-  - TOX_ENV=py33-django1.8-drf3.3
-
-  - TOX_ENV=py34-django1.7-drf3.1
-  - TOX_ENV=py34-django1.7-drf3.2
-  - TOX_ENV=py34-django1.7-drf3.3
-  - TOX_ENV=py34-django1.8-drf3.1
-  - TOX_ENV=py34-django1.8-drf3.2
-  - TOX_ENV=py34-django1.8-drf3.3
-  - TOX_ENV=py34-django1.9-drf3.1
-  - TOX_ENV=py34-django1.9-drf3.2
-  - TOX_ENV=py34-django1.9-drf3.3
-
-  - TOX_ENV=py35-django1.8-drf3.1
-  - TOX_ENV=py35-django1.8-drf3.2
-  - TOX_ENV=py35-django1.8-drf3.3
-  - TOX_ENV=py35-django1.9-drf3.1
-  - TOX_ENV=py35-django1.9-drf3.2
-  - TOX_ENV=py35-django1.9-drf3.3
-
 install:
+  - pip install tox-travis
   # Virtualenv < 14 is required to keep the Python 3.2 builds running.
   - pip install tox "virtualenv<14"
   - pip install tox
 
 script:
-  - tox -e $TOX_ENV
+  - tox


### PR DESCRIPTION
This PR fixes the build by using `tox-travis` to have tox automatically run tests for envs in the envlist corresponding to the python version running under Travis.